### PR TITLE
added a comment regarding access to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker run -d --name html2rss-web \
   -p 3000:3000 \
   gilcreator/html2rss-web
 ```
+Your private feed specified in the `feed.yml` file will be available at `http://SERVER-IP:3000/example.rss`. You can change the name of the feed by editing the name of the `example` section in the `feed.yml` file. 
 
 ### Automatic updating
 


### PR DESCRIPTION
I've encountered that it's not clear which address should be used to request the feed for the example, which is located in feed.yml. feed/example.rss? site/example.rss? Turns out, just an "example.rss". It took me ten minutes. I added a comment for those, like me, who were at a loss.